### PR TITLE
make header up to spec

### DIFF
--- a/lib/marked.js
+++ b/lib/marked.js
@@ -17,7 +17,7 @@ var block = {
   fences: noop,
   hr: /^ {0,3}((?:- *){3,}|(?:_ *){3,}|(?:\* *){3,})(?:\n+|$)/,
   // cap[2] might be ' HEADING # ' and must be trimmed appropriately.
-  heading: /^ *(#{1,6})(.*)(?:\n+|$)/,
+  heading: /^ {0,3}(#{1,6})(?:[^\S\n](.*))?(?:\n+|$)/,
   nptable: noop,
   blockquote: /^( {0,3}> ?(paragraph|[^\n]*)(?:\n|$))+/,
   list: /^( *)(bull) [\s\S]+?(?:hr|def|\n{2,}(?! )(?!\1bull )\n*|\s*$)/,
@@ -93,9 +93,7 @@ block.normal = merge({}, block);
 
 block.gfm = merge({}, block.normal, {
   fences: /^ *(`{3,}|~{3,})[ \.]*(\S+)? *\n([\s\S]*?)\n? *\1 *(?:\n+|$)/,
-  paragraph: /^/,
-  // cap[2] might be ' HEADING # ' and must be trimmed appropriately.
-  heading: /^ *(#{1,6}) (.+)(?:\n+|$)/
+  paragraph: /^/
 });
 
 block.gfm.paragraph = edit(block.paragraph)
@@ -118,6 +116,7 @@ block.tables = merge({}, block.gfm, {
  */
 
 block.pedantic = merge({}, block.normal, {
+  heading: /^ *(#{1,6})(.*)(?:\n+|$)/,
   html: edit(
     '^ *(?:comment *(?:\\n|\\s*$)'
     + '|<(tag)[\\s\\S]+?</\\1> *(?:\\n{2,}|\\s*$)' // closed tag
@@ -238,13 +237,18 @@ Lexer.prototype.token = function(src, top) {
     if (cap = this.rules.heading.exec(src)) {
       src = src.substring(cap[0].length);
       // cap[2] might be ' HEADING # '
-      item = cap[2].trim();
+      item = (cap[2] || '').trim();
       if (item.slice(-1) === '#') {
         // NB replace(/#+$/) is quadratic on mismatch because it's unanchored,
         // so we protect with if-check to ensure it won't mismatch.
-        item = item.replace(/#+$/, '');
+        if (this.options.pedantic) {
+          item = item.replace(/#+$/, '');
+        } else {
+          // CM requires a space before additional #s
+          item = item.replace(/(\s|^)#+$/, '');
+        }
       }
-      item = item.trim()
+      item = item.trim();
       this.tokens.push({
         type: 'heading',
         depth: cap[1].length,

--- a/test/new/nogfm_hashtag.md
+++ b/test/new/nogfm_hashtag.md
@@ -1,5 +1,5 @@
 ---
-gfm: false
+pedantic: true
 ---
 #header
 

--- a/test/specs/commonmark/commonmark-spec.js
+++ b/test/specs/commonmark/commonmark-spec.js
@@ -110,7 +110,7 @@ describe('CommonMark 0.28 ATX headings', function() {
   var section = 'ATX headings';
 
   // var shouldPassButFails = [];
-  var shouldPassButFails = [40, 45, 46, 49];
+  var shouldPassButFails = [40];
 
   var willNotBeAttemptedByCoreTeam = [];
 


### PR DESCRIPTION
This PR makes marked pass commonmark atx headers.

I moved the regular heading regex to pedantic which doesn't require a space between the `#` and the text.